### PR TITLE
docs: freeze public main contribution workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,8 @@ Describe the problem and resulting behavior.
 
 Validation performed (host tests, synthetic fixtures, and CUDA qualification when applicable):
 
+Target Public `main` from a topic branch and wait for the required `Linux host and offline tokenizer build` check before squash merging. See [CONTRIBUTING.md](https://github.com/pixelrhino-ai/vrhino/blob/main/CONTRIBUTING.md). Report unavailable local validation accurately.
+
 For Runtime/backend/precision changes, explain the generic need and how bounded graph semantics and model-neutral policy are preserved. Keep private media, weights, evidence, and generated builds outside Git. Source presence does not establish released model support.
+
+If promoting private research, record its Public base SHA and submit only the clean production diff. Published release tags and assets are immutable; fixes require a new version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,31 @@
 
 Public main is the canonical production source. Start with [source build and tests](docs/source-build.md) and [architecture](docs/architecture.md). Open an issue or pull request with the concrete problem, changed behavior and relevant validation.
 
+## Production contribution workflow
+
+1. Fetch the Public repository and update local main with a fast-forward:
+   `git fetch origin`, `git switch main`, then `git merge --ff-only origin/main`.
+   Here `origin` must be `https://github.com/pixelrhino-ai/vrhino.git`; fork contributors should use their Public upstream remote for these commands.
+2. Create a topic branch from that main, for example `git switch -c feature/<topic>`.
+3. Make a focused production change and keep research history outside the Public repository.
+4. Run relevant local validation. At minimum, run `python3 tools/validate_source_hygiene.py` and `python3 tools/validate_public_contract.py` with the developer prerequisites in [source build and tests](docs/source-build.md). Add the relevant synthetic host tests and, only when applicable to the change, CUDA qualification. Report unavailable validation accurately.
+5. Push the topic branch and open a Pull Request targeting Public `main`. Describe the problem, resulting behavior and validation.
+6. Wait for the required `Linux host and offline tokenizer build` check from the `Public source` workflow. If main advances, update the branch with current Public main and wait for CI again.
+7. Squash merge only after required CI passes. No external reviewer or approval is required for the solo maintainer. Delete the merged topic branch when it is no longer needed.
+
+Recommended branch names are `feature/<topic>`, `fix/<topic>`, `docs/<topic>`, `ci/<topic>` and `release/<version>`. These are lightweight conventions. `research/*` is not a normal Public production branch namespace.
+
+Main requires PRs, current-base CI and linear history; force pushes and deletion are blocked. See [repository governance](docs/repository-governance.md) for the exact settings and emergency policy.
+
+## Architecture and validation
+
+Preserve these boundaries:
+
+- new checkpoint != new Runtime
+- new architecture != new Runtime
+- new backend != architecture implementation
+- new architecture != new Precision Policy
+
 A new architecture describes a genuinely different graph or parameterization and reuses the shared tensor runtime, precision contracts, memory system and backends. A new backend implements generic tensor capabilities. Neither change creates a model-specific runtime or a wrapper around an official Python pipeline.
 
 Keep NeuralGraph semantics bounded and typed. Precision policy is architecture-neutral: the validation matrix may grow, the implementation matrix must not. Do not add model, block, workload or fixed-shape precision exceptions. Runtime changes should include meaningful synthetic positive and rejection tests, relevant host/CUDA qualification, and an explanation of shared operators reused or added.
@@ -11,3 +36,9 @@ Default tests must work offline with synthetic data and redistributable reposito
 Keep generated outputs, weights, private media and qualification archives outside Git. Preserve upstream licenses; identify copied or adapted code and its origin. By submitting project-owned contributions, you submit them under the project Apache-2.0 license unless explicitly stated otherwise. See LICENSE and THIRD_PARTY_NOTICES.md.
 
 Future production work belongs on Public main. Private work is a research, evidence, unreleased experiment and license-sensitive overlay. Source presence alone does not establish release support; do not retroactively expand historical release claims.
+
+Private research starts from a recorded Public main commit SHA. Research history is not production history: reduce any research promoted to production to a clean production diff on a fresh Public topic branch, then use the PR and CI workflow above. Keep research, evidence, artifacts, builds and archive workspaces separate from Public source.
+
+## Published releases
+
+Published tags and releases are immutable by project policy, including the frozen `v0.5.0-alpha`, `v0.6.0-alpha` and `v0.7.0-alpha` releases. Never move a published tag, replace published binary assets, force-update release refs or reuse an existing release version. Fixes require a new version.

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -1,0 +1,42 @@
+# Public main governance v1
+
+Public `pixelrhino-ai/vrhino` main is the only production source of truth. Normal changes follow Public main → topic branch → PR → required Public CI → squash merge → Public main. Follow [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Main protection
+
+The active repository ruleset [Public main protection v1](https://github.com/pixelrhino-ai/vrhino/rules/22619082) targets only `refs/heads/main`. It does not target release tags. There is no redundant classic branch protection rule.
+
+| Setting | Policy |
+| --- | --- |
+| Force pushes / main deletion | Blocked |
+| Pull request before merge | Required |
+| Approvals | 0; no external reviewer required |
+| Code owner / last-push approval / stale approval dismissal | Disabled |
+| Required check | `Linux host and offline tokenizer build` |
+| Check producer | GitHub Actions, integration ID `15368` |
+| Current-base validation | Required; update the topic branch if main advances |
+| Linear history | Required for future changes; existing history stays intact |
+| Signed commits | Not required |
+| Bypass actors | None, including no configured admin bypass |
+| Merge methods | Squash enabled; merge commits and rebase merging disabled |
+| Auto-merge / automatic branch deletion | Disabled |
+
+Squash merging gives each production PR one focused commit. The initial audit found no open PRs and no merge commits in the available history, so this choice preserves a simple history without disrupting pending work. Contributors may delete merged topic branches manually; main deletion remains blocked.
+
+Administrators can edit repository rules. Any administrative relaxation or bypass is **EMERGENCY ONLY**, never the normal development workflow. Record the reason and exact affected SHAs, restore protection promptly and verify CI. Emergency authority never permits rewriting production history or mutating published releases.
+
+## CI contract
+
+The existing [Public source workflow](../.github/workflows/source.yml) runs on pull requests (including those targeting main), pushes to main and manual dispatch. Its stable job name above is the required check, discovered from a successful check run on Public main; the workflow display name is not the check context.
+
+CI runs on Ubuntu 22.04 with CUDA disabled and tokenizers enabled. It validates source hygiene and public contracts, then configures and builds with the network isolated and runs the public host CTest profile. Inputs are synthetic or public repository inputs; no private weights, media, evidence or GPU are required. Installing developer prerequisites requires network access before the offline configure/build boundary. Host CI does not qualify GPU execution or real-model behavior.
+
+Keep this check meaningful and running for every PR to main, including documentation changes. Do not replace it with a skipped or placeholder check. A future rename must coordinate the real workflow check and ruleset so that protection never points at a missing check or admits unvalidated changes.
+
+## Maintainer and release boundaries
+
+`CODEOWNERS_NOT_NEEDED_V1`: the audit found one effective maintainer. CODEOWNERS would add no practical ownership clarity, so none is added and code owner approval is not required.
+
+Published releases and tags are immutable by project policy. `v0.5.0-alpha`, `v0.6.0-alpha` and `v0.7.0-alpha` remain frozen. Do not move published tags, replace binary assets, force-update release refs or reuse versions; fixes require a new version. This branch ruleset does not enforce tag or asset immutability, and the existing releases are not marked immutable by GitHub. Maintainers must preserve the project policy.
+
+Private research starts from a recorded Public SHA, stays in the separate research workspace and enters production only as a clean diff through Public PRs and CI. Local evidence, artifacts, builds and archives stay outside Public Git. Research history is not production history.


### PR DESCRIPTION
Public main previously had no protection and the contribution guide did not specify a required PR/CI workflow. Document the newly active main ruleset, the exact required Public CI check, squash merging with zero approvals, and emergency-only administrative changes.

Expand CONTRIBUTING with the branch-to-PR workflow, architecture boundaries, research promotion policy and published-release immutability. Clarify the PR template and record why CODEOWNERS is unnecessary for the sole maintainer.

Validation: source hygiene and public contract validators pass; `git diff --cached --check` passes. Only CONTRIBUTING.md, the PR template and the governance document change. The existing Public source workflow is unchanged and must pass before this PR merges. No GPU qualification or release package rebuild is part of this documentation change.
